### PR TITLE
Fix reverse tunnel connect/data handler race condition

### DIFF
--- a/client/channel.c
+++ b/client/channel.c
@@ -309,6 +309,27 @@ unsigned char channel_request_tunnel(
 }
 
 /**
+ * acknowledge to the server that the client successfully
+ * connected the reverse tunnel, so that it may now send
+ * data down the tunnel
+ * @param[in] tid the tunnel ID
+ */
+void channel_rconnect_tunnel(unsigned char tid)
+{
+	r2tmsg_t *msg;
+
+	assert(tid != 0xff);
+	trace_chan("tid=0x%02x", tid);
+
+	msg = write_reserve(2, NULL);
+	if (msg) {
+		msg->cmd = R2TCMD_RCONN;
+		msg->id  = tid;
+		write_commit(2);
+	}
+}
+
+/**
  * notify the server a tunnel has been closed
  * @param[in] tid the tunnel ID
  */

--- a/client/r2tcli.h
+++ b/client/r2tcli.h
@@ -126,6 +126,7 @@ void channel_pong(void);
 unsigned char channel_request_tunnel(unsigned char, const char *, unsigned short, int);
 int channel_forward_recv(netsock_t *);
 int channel_forward_iobuf(iobuf_t *, unsigned char);
+void channel_rconnect_tunnel(unsigned char);
 void channel_close_tunnel(unsigned char);
 
 // controller.c

--- a/client/tunnel.c
+++ b/client/tunnel.c
@@ -411,8 +411,10 @@ int tunnel_write(netsock_t *ns, const void *buf, unsigned int len)
  */
 int tunnel_write_event(netsock_t *ns)
 {
-	if ((ns->type == NETSOCK_RTUNCLI) && (ns->state != NETSTATE_CONNECTED))
+	if ((ns->type == NETSOCK_RTUNCLI) && (ns->state != NETSTATE_CONNECTED)) {
 		ns->state = NETSTATE_CONNECTED;
+		channel_rconnect_tunnel(ns->tid);
+	}
 
 	return netsock_write(ns, NULL, 0);
 }

--- a/common/print.c
+++ b/common/print.c
@@ -169,7 +169,7 @@ int error(const char *fmt, ...)
  */
 void print_xfer(const char *name, char rw, unsigned int size)
 {
-	debug(1, (rw=='r'?"%-6s          < %-8u":"%-6s %8u >"), name, size);
+	debug(PRINT_DBG, (rw=='r'?"%-6s          < %-8u":"%-6s %8u >"), name, size);
 }
 
 #ifdef DEBUG

--- a/server/commands.c
+++ b/server/commands.c
@@ -100,12 +100,27 @@ static int cmd_data(const r2tmsg_t *msg, unsigned int len)
 	return tunnel_write(tun, ((const char *)msg)+2, len-2);
 }
 
+static int cmd_rconn(const r2tmsg_t *msg, unsigned int len)
+{
+	tunnel_t *tun;
+	
+	trace_chan("len=%u, id=0x%02x", len, msg->id);
+	tun = tunnel_lookup(msg->id);
+	if (!tun) {
+		error("invalid tunnel id 0x%02x", msg->id);
+		return 0;
+	}
+	tun->connected = 1;
+
+	return 0;
+}
+
 const cmdhandler_t cmd_handlers[R2TCMD_MAX] = {
 	(cmdhandler_t) cmd_conn,  /* R2TCMD_CONN */
 	(cmdhandler_t) cmd_close, /* R2TCMD_CLOSE */
 	(cmdhandler_t) cmd_data,  /* R2TCMD_DATA */
 	NULL,
 	(cmdhandler_t) cmd_bind,  /* R2TCMD_BIND */
-	NULL
+	(cmdhandler_t) cmd_rconn  /* R2TCMD_RCONN */
 };
 

--- a/server/tunnel.c
+++ b/server/tunnel.c
@@ -416,7 +416,7 @@ static int tunnel_accept_event(tunnel_t *tun)
 	}
 	cli->sock.fd   = cli_sock.fd;
 	cli->sock.evt  = cli_sock.evt;
-	cli->connected = 1;
+	cli->connected = 0;
 	cli->id        = tid;
 	iobuf_init2(&cli->rio.buf, &cli->wio.buf, "tcp");
 	list_add_tail(&cli->list, &all_tunnels);
@@ -501,7 +501,8 @@ int tunnel_event(tunnel_t *tun, HANDLE h)
 
 			if ((ret >= 0) && (evt & FD_READ)) {
 				debug(0, "FD_READ");
-				ret = tunnel_sockrecv_event(tun);
+				if (tun->connected)
+				    ret = tunnel_sockrecv_event(tun);
 				if (evt & FD_CLOSE)
 				    while ((ret = tunnel_sockrecv_event(tun)) > 0);
 			}


### PR DESCRIPTION
There was a problem whereby on a reverse tunnel, the server process
would trigger the connection to start on the client. However, if the
client was a bit slow to connect (as the attempt is a non-blocking
one), the server is unaware. It would then pass on data it read on the
server side, down the tunnel, for the client to process.

The client would try to perform that data handling on a TCP connection
which was not yet established, and errors would result.

Fix this by utilising the R2TCMD_RCONN message, in reverse, to signal
to the server that the client connected the reverse tunnel first. The
server would ignore read data for the tunnel until the client
confirmed connection.